### PR TITLE
Add msmpeg2vdec.dll and xpsp2res.dll to known_modules.

### DIFF
--- a/known_modules/msmpeg2vdec.dll.txt
+++ b/known_modules/msmpeg2vdec.dll.txt
@@ -1,0 +1,1 @@
+Microsoft MPEG decoder

--- a/known_modules/xpsp2res.dll.txt
+++ b/known_modules/xpsp2res.dll.txt
@@ -1,0 +1,1 @@
+Microsoft


### PR DESCRIPTION
msmpeg2vdec.dll is part of Microsoft's MPEG decoder, but they don't
provide symbols for it on their symbol server for some reason. There's
no point in having it in the report.

xpsp2res.dll is part of Windows XP, which we no longer support anyway,
and is a resource-only DLL that doesn't have symbols.