### PR TITLE
Add icudt5{2,6}.dll to known symbols

### DIFF
--- a/known_modules/icudt52.dll.txt
+++ b/known_modules/icudt52.dll.txt
@@ -1,0 +1,1 @@
+ICU data shipped with Firefox, no symbols present.

--- a/known_modules/icudt56.dll.txt
+++ b/known_modules/icudt56.dll.txt
@@ -1,0 +1,1 @@
+ICU data shipped with Firefox, no symbols present.


### PR DESCRIPTION
icudtNN.dll was shipped in older versions of Firefox but it just contains ICU data. It doesn't contain any executable code, so it doesn't have symbols available. It does get loaded into memory so presumably the stackwalker winds up with spurious frames in there enough to make it show up on the missing symbols report.